### PR TITLE
use x_display_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ option (oapi.v1.file) = {
 service MyService {
   option (oapi.v1.service) = {
     prefix: "/v1"
-    display_name: "My Service"
+    x_display_name: "My Service"
   };
 
   rpc CreateSomething (CreateSomethingRequest) returns (CreateSomethingResponse) {


### PR DESCRIPTION
Update example in README.md as `display_name` makes the generate to fail. Seems like it needs to be `x_display_name`

```bash
$ buf generate api
$ api/v2/myservice.proto:15:9:service MyService: option (oapi.v1.service): field display_name not found
```