### PR TITLE
Add proto3 string enum support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.19-alpine3.16 as build
+FROM golang:1.21-alpine3.18 as build
 
-ENV CGO_ENABLED=0 
+ENV CGO_ENABLED=0
 
 RUN apk add gcc protoc protobuf-dev
 

--- a/test/field_test.proto
+++ b/test/field_test.proto
@@ -44,6 +44,11 @@ message TestFieldTypesRequest {
     string string = 1;
   }
 
+  enum Enum {
+    ENUM_UNSPECIFIED = 0;
+    ENUM_VALUE = 1;
+  }
+
   string string = 1 [(oapi.v1.options) = {
     enum: ["test"]
   }];
@@ -55,6 +60,8 @@ message TestFieldTypesRequest {
   repeated string repeated_string = 7;
   repeated Message repeated_message = 8;
   repeated MessageRequest repeated_request = 9;
+  Enum enum = 10;
+  repeated Enum repeated_enum = 11;
 }
 
 message TestFieldTypesResponse {}

--- a/test/field_test_openapi.yaml
+++ b/test/field_test_openapi.yaml
@@ -28,6 +28,18 @@ paths:
                   type: integer
                 uint64:
                   type: string
+                enum:
+                  type: string
+                  enum:
+                    - ENUM_UNSPECIFIED
+                    - ENUM_VALUE
+                repeated_enum:
+                  type: array
+                  items:
+                    type: string
+                    enum:
+                      - ENUM_UNSPECIFIED
+                      - ENUM_VALUE
                 repeated_string:
                   items:
                     type: string


### PR DESCRIPTION
In proto3, enums are canonically serialized as their string values (in JSON). While it's possible for libraries to allow this to be overridden to use int values, that's not the default and is not particularly useful for OpenAPI schema generation.

Source: https://protobuf.dev/programming-guides/proto3/#json-options

> **Emit enum values as integers instead of strings**
>
> The name of an enum value is used by default in JSON output.
> An option may be provided to use the numeric value of the enum
> value instead.

No support is added here for falling back to numeric values in the generated schema. Similarly, the proto3 docs show an example of attaching extra enum value options, such as a custom string value. These could be added to `oapi/v1/field.proto` in the future if needed.